### PR TITLE
manpage in the debian package

### DIFF
--- a/.github/workflows/releaseworkflow.yml
+++ b/.github/workflows/releaseworkflow.yml
@@ -52,9 +52,31 @@ jobs:
         run: |
           mkdir -p debbuild/DEBIAN
           mkdir -p debbuild/usr/local/bin
+          mkdir -p debbuild/usr/local/man
 
           cp target/release/simeis-server debbuild/usr/local/bin/
-          
+                  
+                  cat <<EOF > debbuild/usr/local/man
+
+          .\" Manpage for simeis but not really hihi.
+          .\" Contact no one to correct errors or typos. We don't do any
+          .TH man 1 "04 july 2025" "1.0" "simeis"
+          .SH NAME
+          Simeis is a nice game if you forget about le destructeur de marché.
+          .SH SYNOPSIS
+          In a galaxy far, far away, you could fight oppression but instead, you are mining.
+          .SH DESCRIPTION
+          Go mine.
+          .SH OPTIONS
+          The nuseradd does not take any options. However, you can supply username.
+          .SH SEE ALSO
+          Nowhere, you must mine.
+          .SH BUGS
+          No known bugs.
+          .SH AUTHOR
+          Timothée Cercueil but the bot is mine.
+          EOF
+
                   cat <<EOF > debbuild/DEBIAN/control
           Package: simeis-server
           Version: ${VERSION}


### PR DESCRIPTION
## Résumé des changements

- Mise en place de la CI complète pour un projet Rust :
  - Tests automatiques (`cargo test`)
  - Linting (`cargo clippy`)
  - Format (`cargo fmt`)
  - Build release conditionnel (`main` uniquement)
  - Compilation automatique de la documentation Typst

- Mise en place de la mise à jour automatique des dépendances (`DIY Dependabot`) :
  - `cargo update`
  - `cargo install-update -a`
  - Création de PR automatique si changements détectés

- Définition de propriétaires de code via `CODEOWNERS` :
  - Assignation automatique de reviewers en fonction des fichiers modifiés

- Mise en place de règles de protection de branche :
  - PR obligatoire
  - Validation des checks avant merge
  - Interdiction de merger sans validation d’un reviewer

---

## Objectif de cette PR

- [x] Tests
- [x] Lint + Format
- [x] CI Rust optimisée
- [x] Automatisation des updates de dépendances
- [x] Sécurité du repo (code owners + branch protection)
- [x] Documentation

---

## Checklist qualité

- [x] La PR a un titre clair et explicite
- [x] Le code est formaté (`cargo fmt`)
- [x] Le lint passe sans warning (`cargo clippy`)
- [x] Les tests unitaires passent (`cargo test`)
- [x] La documentation Typst compile
- [x] La CI passe entièrement
- [x] Les reviewers sont bien assignés automatiquement

---



## Notes complémentaires

- Pour installer Typst dans GitHub Actions, on passe par `curl + tar` car `apt` ne le propose pas sous Ubuntu 24.04.
- Le système de release est conditionné au push sur la branche `main`.
- Le workflow Dependabot personnalisé se déclenche chaque lundi ou manuellement via `workflow_dispatch`.
