### PR TITLE
Bug/manpagebug

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,20 +1,13 @@
 FROM debian:bookworm-slim
 
-
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl \
         ca-certificates \
-        build-essential \
-        gcc \
-        libssl-dev \
-        pkg-config \
-        git \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.85.0
+COPY target/release/simeis-server-*.deb /tmp/simeis.deb
 
-ENV PATH="/root/.cargo/bin:${PATH}"
+RUN apt-get update && apt-get install -y /tmp/simeis.deb || apt-get -f install -y && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN cargo build --release\
-    cargo run --release 
+CMD ["simeis-server"]

--- a/.github/workflows/releaseworkflow.yml
+++ b/.github/workflows/releaseworkflow.yml
@@ -31,28 +31,6 @@ jobs:
       - name: Installer Rust
         uses: dtolnay/rust-toolchain@stable
       
-      - name: Compilation release
-        run: cargo build --release
-      - name: "Cache cargo"
-        id: cachecargo
-        uses: "actions/cache@v4"
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          save-always: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
-      - name: Installer Rust
-        uses: dtolnay/rust-toolchain@stable
-      
-      - name: Compilation release
-        run: cargo build --release
-
       - name: Extract version from branch name
         run: |
           BRANCH_NAME="${{ github.event.pull_request.base.ref }}"


### PR DESCRIPTION
## Résumé des changements

- Mise en place de la CI complète pour un projet Rust :
  - Tests automatiques (`cargo test`)
  - Linting (`cargo clippy`)
  - Format (`cargo fmt`)
  - Build release conditionnel (`main` uniquement)
  - Compilation automatique de la documentation Typst

- Mise en place de la mise à jour automatique des dépendances (`DIY Dependabot`) :
  - `cargo update`
  - `cargo install-update -a`
  - Création de PR automatique si changements détectés

- Définition de propriétaires de code via `CODEOWNERS` :
  - Assignation automatique de reviewers en fonction des fichiers modifiés

- Mise en place de règles de protection de branche :
  - PR obligatoire
  - Validation des checks avant merge
  - Interdiction de merger sans validation d’un reviewer

---

## Objectif de cette PR

- [x] Tests
- [x] Lint + Format
- [x] CI Rust optimisée
- [x] Automatisation des updates de dépendances
- [x] Sécurité du repo (code owners + branch protection)
- [x] Documentation

---

## Checklist qualité

- [x] La PR a un titre clair et explicite
- [x] Le code est formaté (`cargo fmt`)
- [x] Le lint passe sans warning (`cargo clippy`)
- [x] Les tests unitaires passent (`cargo test`)
- [x] La documentation Typst compile
- [x] La CI passe entièrement
- [x] Les reviewers sont bien assignés automatiquement

---



## Notes complémentaires

- Pour installer Typst dans GitHub Actions, on passe par `curl + tar` car `apt` ne le propose pas sous Ubuntu 24.04.
- Le système de release est conditionné au push sur la branche `main`.
- Le workflow Dependabot personnalisé se déclenche chaque lundi ou manuellement via `workflow_dispatch`.
